### PR TITLE
Make switching to file polling possible

### DIFF
--- a/frontend/.env.local.sample
+++ b/frontend/.env.local.sample
@@ -1,6 +1,7 @@
 NEXT_PUBLIC_DATABASE_URL=https://local.solarbuildingenvelopes.com:5051
 NEXT_PUBLIC_METABASE_URL=https://local.buildingenvelopedata.org:4041
 NEXTAUTH_URL=https://local.solarbuildingenvelopes.com:5051
+NEXT_WEBPACK_USEPOLLING=false
 
 AUTH_CLIENT_ID=testlab-solar-facades
 AUTH_CLIENT_SECRET=secret

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,8 +1,0 @@
-NEXT_PUBLIC_DATABASE_URL=https://local.solarbuildingenvelopes.com:5051
-NEXT_PUBLIC_METABASE_URL=https://local.buildingenvelopedata.org:4041
-NEXTAUTH_URL=https://local.solarbuildingenvelopes.com:5051
-
-AUTH_CLIENT_ID=testlab-solar-facades
-AUTH_CLIENT_SECRET=secret
-AUTH_SECRET=secret
-AUTH_JWT_SECRET=INp8IvdIyeMcoGAgFGoA61DdBglwwSqnXJZkgz8PSnw

--- a/frontend/environment.d.ts
+++ b/frontend/environment.d.ts
@@ -4,6 +4,7 @@ declare global {
       NEXT_PUBLIC_DATABASE_URL: string;
       NEXT_PUBLIC_METABASE_URL: string;
       NEXTAUTH_URL: string;
+      NEXT_WEBPACK_USEPOLLING: string;
       NODE_ENV: "test" | "development" | "production";
       AUTH_CLIENT_ID: string;
       AUTH_CLIENT_SECRET: string;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,8 @@
-module.exports = {
-  webpack(config, options) {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+  webpack: (config, options) => {
     config.module.rules.push({
       test: /\.graphql$/,
       exclude: /node_modules/,
@@ -18,6 +21,17 @@ module.exports = {
       use: "yaml-loader",
     });
 
+    // Enable polling based on env variable being set
+    // Inspired by https://medium.com/mikkotikkanen/solving-next-js-fast-refresh-on-docker-windows-71dfdb3ee785
+    if (process.env.NEXT_WEBPACK_USEPOLLING == "true" || false) {
+      config.watchOptions = {
+        poll: 500,
+        aggregateTimeout: 300
+      }
+    }
+
     return config;
   },
-};
+}
+
+module.exports = nextConfig;


### PR DESCRIPTION
There is [an open issue regarding Fast Refresh not working on Docker with Windows](https://github.com/vercel/next.js/issues/36774). And a possible fix is mentioned in [Solving Next.js fast refresh on Docker+Windows](https://medium.com/mikkotikkanen/solving-next-js-fast-refresh-on-docker-windows-71dfdb3ee785).

@christoph-maurer When this branch is merged, you'll need to add, `NEXT_WEBPACK_USEPOLLING=false` to your `./frontend/.env.local` file.

@jbinterap  When this branch is merged, you'll need to add, `NEXT_WEBPACK_USEPOLLING=true` to your `./frontend/.env.local` file.